### PR TITLE
Minor CMake Add-ons and Hypre Compatibility Changes 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ sudo: true
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo rm /usr/local/include/c++ ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install mpich2 lapack cmake; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install mpich2 lapack; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade cmake; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install cmake mpich2 liblapack-dev ; fi
 before_script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ install:
 before_script: 
   - mkdir build
   - cd build
-  - cmake ..
+  - cmake .. 
 script: make && make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ sudo: true
 install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo rm /usr/local/include/c++ ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install mpich2 lapack ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install mpich2 lapack cmake; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install cmake mpich2 liblapack-dev ; fi
 before_script: 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ elseif (BGQ)
     find_library(XLSMP_LIB NAMES libxlomp_ser.a xlomp_ser HINTS
         "/soft/compilers/ibmcmp-may2016/xlsmp/bg/3.1/bglib64")
 
-    set(EXTERNAL_LIBS ${LAPACK_LIB} ${BLAS_LIB} ${ESSL_LIB} ${XLF_LIB} 
+    set(EXTERNAL_LIBS ${LAPACK_LIB} ${BLAS_LIB} ${ESSL_LIB} ${XLF_LIB}
         ${XLOPT_LIB} ${XLFMATH_LIB} ${XL_LIB} ${XLSMP_LIB})
 else()
 	find_library(LAPACK_LIB NAMES liblapack.so.3 lapack HINTS "/usr/lib/x86_64-linux-gnu/")
@@ -113,6 +113,7 @@ if(WITH_MFEM)
 		endif(HYPRE_FOUND)
 	endif(NOT HYPRE_FOUND)
 
+    add_definitions ( -DUSING_METIS )
 	find_package(Metis)
 	if(METIS_FOUND)
 		include_directories(${METIS_INCLUDE_DIRS})
@@ -124,7 +125,7 @@ if(WITH_MFEM)
 	if (MFEM_FOUND)
 		include_directories(${MFEM_INCLUDE_DIRS})
 	else()
-		message(FATAL_ERROR "Cannot find mfem. Try setting MFEM_DIR.")	
+		message(FATAL_ERROR "Cannot find mfem. Try setting MFEM_DIR.")
 	endif(MFEM_FOUND)
 endif(WITH_MFEM)
 

--- a/cmake/FindHypre.cmake
+++ b/cmake/FindHypre.cmake
@@ -4,12 +4,14 @@ find_package(PkgConfig)
 pkg_check_modules(HYPRE QUIET hypre)
 
 find_path(HYPRE_INCLUDE_DIR HYPRE.h
-          HINTS ${PC_HYPRE_INCLUDEDIR} ${PC_HYPRE_INCLUDE_DIRS} 
-			${HYPRE_DIR}/include ${HYPRE_DIR}/src/hypre/include)
+          HINTS ${PC_HYPRE_INCLUDEDIR} ${PC_HYPRE_INCLUDE_DIRS}
+          ${HYPRE_DIR}/include ${HYPRE_DIR}/src/hypre/include
+          $ENV{HYPRE_DIR}/include $ENV{HYPRE_DIR}/src/hypre/include)
 
 find_library(HYPRE_LIBRARY NAMES HYPRE
-             HINTS ${PC_HYPRE_LIBDIR} ${PC_HYPRE_LIBRARY_DIRS} 
-			 ${HYPRE_DIR}/lib ${HYPRE_DIR}/src/hypre/lib)
+             HINTS ${PC_HYPRE_LIBDIR} ${PC_HYPRE_LIBRARY_DIRS}
+             ${HYPRE_DIR}/lib ${HYPRE_DIR}/src/hypre/lib
+             $ENV{HYPRE_DIR}/lib $ENV{HYPRE_DIR}/src/hypre/lib)
 
 set(HYPRE_LIBRARIES ${HYPRE_LIBRARY} )
 set(HYPRE_INCLUDE_DIRS ${HYPRE_INCLUDE_DIR} )

--- a/cmake/FindMetis.cmake
+++ b/cmake/FindMetis.cmake
@@ -5,11 +5,11 @@ pkg_check_modules(METIS QUIET metis)
 
 find_path(METIS_INCLUDE_DIR metis.h
           HINTS ${PC_METIS_INCLUDEDIR} ${PC_METIS_INCLUDE_DIRS}
-			${METIS_DIR}/include)
+          ${METIS_DIR}/Lib $ENV{METIS_DIR}/Lib)
 
-find_library(METIS_LIBRARY NAMES metis
+find_library(METIS_LIBRARY NAMES libmetis.a
              HINTS ${PC_METIS_LIBDIR} ${PC_METIS_LIBRARY_DIRS}
-				${METIS_DIR}/libmetis ${METIS_DIR}/lib)
+             ${METIS_DIR} $ENV{METIS_DIR})
 
 set(METIS_LIBRARIES ${METIS_LIBRARY} )
 set(METIS_INCLUDE_DIRS ${METIS_INCLUDE_DIR} )

--- a/cmake/FindMfem.cmake
+++ b/cmake/FindMfem.cmake
@@ -5,11 +5,13 @@ pkg_check_modules(MFEM QUIET mfem)
 
 find_path(MFEM_INCLUDE_DIR mfem.hpp
           HINTS ${PC_MFEM_INCLUDEDIR} ${PC_MFEM_INCLUDE_DIRS}
-			${MFEM_DIR} ${MFEM_DIR}/include)
+		  ${MFEM_DIR} ${MFEM_DIR}/include	
+          $ENV{MFEM_DIR} $ENV{MFEM_DIR}/include)
 
 find_library(MFEM_LIBRARY NAMES mfem
              HINTS ${PC_MFEM_LIBDIR} ${PC_MFEM_LIBRARY_DIRS}
-				${MFEM_DIR} ${MFEM_DIR}/lib)
+             ${MFEM_DIR} ${MFEM_DIR}/lib
+				$ENV{MFEM_DIR} $ENV{MFEM_DIR}/lib)
 
 set(MFEM_LIBRARIES ${MFEM_LIBRARY} )
 set(MFEM_INCLUDE_DIRS ${MFEM_INCLUDE_DIR} )

--- a/cmake/FindPtscotch.cmake
+++ b/cmake/FindPtscotch.cmake
@@ -5,39 +5,39 @@ pkg_check_modules(PTSCOTCH QUIET ptscotch)
 
 find_path(PTSCOTCH_INCLUDE_DIR ptscotch.h
             HINTS ${PC_PTSCOTCH_INCLUDEDIR} ${PC_PTSCOTCH_INCLUDE_DIRS} 
-            ${PTSCOTCH_DIR}/include)
+            ${PTSCOTCH_DIR}/include $ENV{PTSCOTCH_DIR}/include)
 
 find_library(PTSCOTCH_LIBRARY NAMES ptscotch
             HINTS ${PC_PTSCOTCH_LIBDIR} ${PC_PTSCOTCH_LIBRARY_DIRS} 
-            ${PTSCOTCH_DIR}/lib)
+            ${PTSCOTCH_DIR}/lib $ENV{PTSCOTCH_DIR}/lib)
 
 find_library(PTSCOTCH_ERR_LIBRARY NAMES ptscotcherr
             HINTS ${PC_PTSCOTCH_LIBDIR} ${PC_PTSCOTCH_LIBRARY_DIRS} 
-            ${PTSCOTCH_DIR}/lib)
+            ${PTSCOTCH_DIR}/lib $ENV{PTSCOTCH_DIR}/lib)
 
 find_library(PTSCOTCH_ERR_EXIT_LIBRARY NAMES ptscotcherrexit
             HINTS ${PC_PTSCOTCH_LIBDIR} ${PC_PTSCOTCH_LIBRARY_DIRS}
-            ${PTSCOTCH_DIR}/lib)
+            ${PTSCOTCH_DIR}/lib $ENV{PTSCOTCH_DIR}/lib)
 
 find_library(PTSCOTCH_PARMETIS_LIBRARY NAMES ptscotchparmetis
             HINTS ${PC_PTSCOTCH_LIBDIR} ${PC_PTSCOTCH_LIBRARY_DIRS}
-            ${PTSCOTCH_DIR}/lib)
+            ${PTSCOTCH_DIR}/lib $ENV{PTSCOTCH_DIR}/lib)
 
 find_library(SCOTCH_LIBRARY NAMES scotch
             HINTS ${PC_PTSCOTCH_LIBDIR} ${PC_PTSCOTCH_LIBRARY_DIRS} 
-            ${PTSCOTCH_DIR}/lib)
+            ${PTSCOTCH_DIR}/lib $ENV{PTSCOTCH_DIR}/lib)
 
 find_library(SCOTCH_ERR_LIBRARY NAMES scotcherr
             HINTS ${PC_PTSCOTCH_LIBDIR} ${PC_PTSCOTCH_LIBRARY_DIRS} 
-            ${PTSCOTCH_DIR}/lib)
+            ${PTSCOTCH_DIR}/lib $ENV{PTSCOTCH_DIR}/lib)
 
 find_library(SCOTCH_ERR_EXIT_LIBRARY NAMES scotcherrexit
             HINTS ${PC_PTSCOTCH_LIBDIR} ${PC_PTSCOTCH_LIBRARY_DIRS}
-            ${PTSCOTCH_DIR}/lib)
+            ${PTSCOTCH_DIR}/lib $ENV{PTSCOTCH_DIR}/lib)
 
 find_library(SCOTCH_METIS_LIBRARY NAMES scotchmetis
             HINTS ${PC_PTSCOTCH_LIBDIR} ${PC_PTSCOTCH_LIBRARY_DIRS}
-            ${PTSCOTCH_DIR}/lib)
+            ${PTSCOTCH_DIR}/lib $ENV{PTSCOTCH_DIR}/lib)
 
 set(PTSCOTCH_LIBRARIES ${PTSCOTCH_LIBRARY} ${PTSCOTCH_ERR_LIBRARY}
     ${PTSCOTCH_ERR_EXIT_LIBRARY} ${PTSCOTCH_PARMETIS_LIBRARY}

--- a/examples/profile_rss.cpp
+++ b/examples/profile_rss.cpp
@@ -381,7 +381,7 @@ int main(int argc, char *argv[])
         if (rank == 0) printf("TAP A mult P Time: %e\n", t0);
 
         // TIME P^T*(AP) on Level i
-        ParCSCMatrix* Pcsc = new ParCSCMatrix(Pl);
+        ParCSCMatrix* Pcsc = Pl->to_ParCSC();
         ParCSRMatrix* Actmp;
         clear_cache(cache_array);
         MPI_Barrier(MPI_COMM_WORLD);

--- a/raptor/ruge_stuben/tests/test_hypre_agg.cpp
+++ b/raptor/ruge_stuben/tests/test_hypre_agg.cpp
@@ -117,11 +117,11 @@ TEST(TestHypreAgg, TestsInRuge_Stuben)
 
         // SpGEMM (Form Ac)
         ParCSRMatrix* APl = Al->mult(Pl);
-        ParCSCMatrix* Pcsc = new ParCSCMatrix(Pl);
+        ParCSCMatrix* Pcsc = Pl->to_ParCSC();
         ParCSRMatrix* Ac = APl->mult_T(Pcsc);
         Ac->comm = new ParComm(Ac->partition, Ac->off_proc_column_map, Ac->on_proc_column_map);
         A_array.push_back(Ac);
-        hypre_BoomerAMGBuildCoarseOperatorKT(P_hyp, A_hyp, P_hyp, 0, &Ac_hyp);
+        hypre_BoomerAMGBuildCoarseOperator(P_hyp, A_hyp, P_hyp, &Ac_hyp);
         compare(Ac, Ac_hyp);
                 
 

--- a/raptor/ruge_stuben/tests/test_hypre_unknown.cpp
+++ b/raptor/ruge_stuben/tests/test_hypre_unknown.cpp
@@ -150,12 +150,12 @@ TEST(TestParSplitting, TestsInRuge_Stuben)
     compare(P, P_hyp);
 
     ParCSRMatrix* APtmp = A->mult(P);
-    ParCSCMatrix* Pcsc = new ParCSCMatrix(P);
+    ParCSCMatrix* Pcsc = P->to_ParCSC(); //new ParCSCMatrix(P);
     ParCSRMatrix* Ac = APtmp->mult_T(Pcsc);
     delete APtmp;
     delete Pcsc;
     hypre_ParCSRMatrix* A_H;
-    hypre_BoomerAMGBuildCoarseOperatorKT(P_hyp, A_hyp, P_hyp, false, &A_H);
+    hypre_BoomerAMGBuildCoarseOperator(P_hyp, A_hyp, P_hyp,  &A_H);
     compare(Ac, A_H);
 
 

--- a/raptor/tests/hypre_compare.hpp
+++ b/raptor/tests/hypre_compare.hpp
@@ -116,7 +116,7 @@ void compare(ParCSRMatrix* A, hypre_ParCSRMatrix* A_h)
         if (end - start)
         {
             if (diag_j[start] == i) start++;
-            hypre_qsort1(diag_j, diag_data, start, end - 1);
+            qsort1(diag_j, diag_data, start, end - 1);
         }
 
         if (offd_cols)
@@ -125,7 +125,7 @@ void compare(ParCSRMatrix* A, hypre_ParCSRMatrix* A_h)
             end = offd_i[i+1];
             if (end - start)
             {
-                hypre_qsort1(offd_j, offd_data, start, end - 1);
+                qsort1(offd_j, offd_data, start, end - 1);
             }
         }
     }
@@ -210,14 +210,14 @@ void compareS(ParCSRMatrix* S, hypre_ParCSRMatrix* S_h)
         end = diag_i[i+1];
         if (end - start)
         {
-            hypre_qsort0(diag_j, start, end - 1);
+            qsort0(diag_j, start, end - 1);
         }
 
         start = offd_i[i];
         end = offd_i[i+1];
         if (end - start)
         {
-            hypre_qsort0(offd_j, start, end - 1);
+            qsort0(offd_j, start, end - 1);
         }
     }
 


### PR DESCRIPTION
I modified CMake files such that one can specify library directories through environment variables, in addition to command line variables (cmake -D*). 

In the process of linking the hypre-2.10.0b, I had to update various HYPRE function calls to match the new interface. 

Everything compiles and all the unit test pass without any issues on porter cluster. 